### PR TITLE
core project depends on vector tile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,11 @@ lazy val commonSettings = Seq(
 lazy val root = Project("demo", file("."))
   .aggregate(ingest, server, core)
 
+lazy val vectorTile = Project("scala-vector-tile", file("scala-vector-tile"))
+  .settings(commonSettings: _*)
+
 lazy val core = Project("core", file("core"))
+  .dependsOn(vectorTile)  
   .settings(commonSettings: _*)
 
 lazy val ingest = Project("ingest", file("ingest"))


### PR DESCRIPTION
So it can be used to read in some sweet vector tiles.

``` console
~/proj/geotrellis-osm-elevation master*
❯ sbt
[info] Loading global plugins from /Users/eugene/.sbt/0.13/plugins
[info] Loading project definition from /Users/eugene/proj/geotrellis-osm-elevation/project
[info] Compiling 1 Scala source to /Users/eugene/proj/geotrellis-osm-elevation/project/target/scala-2.10/sbt-0.13/classes...
[info] Set current project to demo (in build file:/Users/eugene/proj/geotrellis-osm-elevation/)
> project core
[info] Set current project to core (in build file:/Users/eugene/proj/geotrellis-osm-elevation/)
core > console
[info] Updating {file:/Users/eugene/proj/geotrellis-osm-elevation/}scala-vector-tile...
[info] Resolving org.scala-lang#scalap;2.10.5 ...
[info] Done updating.
[warn] Scala version was updated by one of library dependencies:
[warn]  * org.scala-lang:scala-library:(2.10.5, 2.10.2, 2.10.4) -> 2.10.6
[warn] To force scalaVersion, add the following:
[warn]  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
[warn] Run 'evicted' to see detailed eviction warnings
[info] Updating {file:/Users/eugene/proj/geotrellis-osm-elevation/}core...
[info] Resolving org.scala-lang#scalap;2.10.5 ...
[info] Done updating.
[warn] Scala version was updated by one of library dependencies:
[warn]  * org.scala-lang:scala-library:(2.10.5, 2.10.0, 2.10.2, 2.10.4) -> 2.10.6
[warn] To force scalaVersion, add the following:
[warn]  ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
[warn] Run 'evicted' to see detailed eviction warnings
[info] Compiling 3 Scala sources to /Users/eugene/proj/geotrellis-osm-elevation/scala-vector-tile/target/scala-2.10/classes...
[info] Starting scala interpreter...
[info]
Welcome to Scala version 2.10.5 (Java HotSpot(TM) 64-Bit Server VM, Java 1.7.0_55).
Type in expressions to have them evaluated.
Type :help for more information.

scala> import geotrellis.vectortile._
import geotrellis.vectortile._

scala> new VectorTile("/Users/eugene/Downloads/6160.mvt")
res0: geotrellis.vectortile.VectorTile = geotrellis.vectortile.VectorTile@6b8c6214

scala>
[success] Total time: 91 s, completed Apr 28, 2016 11:03:31 AM
```
